### PR TITLE
- changed the syntax for g_ld700i_step (which is currently unimplemen…

### DIFF
--- a/include/ldp-in/ld700-interpreter.h
+++ b/include/ldp-in/ld700-interpreter.h
@@ -45,8 +45,8 @@ extern void (*g_ld700i_stop)();
 // ejects the laserdisc
 extern void (*g_ld700i_eject)();
 
-// steps forward or backward (1 for forward, -1 for backward)
-extern void (*g_ld700i_step)(int8_t i8TracksToStep);
+// steps forward or backward
+extern void (*g_ld700i_step)(LD700_BOOL bBackward);
 
 // begins searching to a frame (non-blocking, should return immediately).
 extern void (*g_ld700i_begin_search)(uint32_t uFrameNumber);

--- a/src/ld700-interpreter.c
+++ b/src/ld700-interpreter.c
@@ -5,7 +5,7 @@ void (*g_ld700i_play)() = 0;
 void (*g_ld700i_pause)() = 0;
 void (*g_ld700i_stop)() = 0;
 void (*g_ld700i_eject)() = 0;
-void (*g_ld700i_step)(int8_t i8TracksToStep) = 0;
+void (*g_ld700i_step)(LD700_BOOL bBackward) = 0;
 void (*g_ld700i_begin_search)(uint32_t uFrameNumber) = 0;
 void (*g_ld700i_change_audio)(LD700_BOOL bEnableLeft, LD700_BOOL bEnableRight) = 0;
 void (*g_ld700i_error)(LD700ErrCode_t code, uint8_t u8Val) = 0;
@@ -174,6 +174,7 @@ void ld700i_write(uint8_t u8Cmd, const LD700Status_t status)
 			{
 				g_ld700i_error(LD700_ERR_UNHANDLED_SITUATION, 0);
 			}
+			u8NewExtAckVsyncCounter = NO_CHANGE;	// I've never seen this command respond with an ACK
 			break;
 		case 0x17:	// play
 

--- a/tests/ld700_tests.cpp
+++ b/tests/ld700_tests.cpp
@@ -119,8 +119,10 @@ TEST_F(LD700Tests, reject_from_playing)
 	m_curStatus = LD700_PLAYING;
 	EXPECT_CALL(mockLD700, Stop());
 	EXPECT_CALL(mockLD700, OnError(_, _)).Times(0);
+	EXPECT_CALL(mockLD700, OnExtAckChanged(_)).Times(0);	// reject should not ACK
 
 	ld700_write_helper(0x16);	// reject (to stop playing)
+	ld700i_on_vblank(m_curStatus);
 }
 
 TEST_F(LD700Tests, reject_from_stopped)
@@ -128,8 +130,10 @@ TEST_F(LD700Tests, reject_from_stopped)
 	m_curStatus = LD700_STOPPED;
 	EXPECT_CALL(mockLD700, Eject());
 	EXPECT_CALL(mockLD700, OnError(_, _)).Times(0);
+	EXPECT_CALL(mockLD700, OnExtAckChanged(_)).Times(0);	// reject should not ACK
 
 	ld700_write_helper(0x16);	// reject (to stop playing)
+	ld700i_on_vblank(m_curStatus);
 }
 
 TEST_F(LD700Tests, playing)


### PR DESCRIPTION
…ted) since we just need to know if the step is going forward or backward

- fixed reject command so that it does  not ACK